### PR TITLE
物理名categoryのコメント修正

### DIFF
--- a/sql/user_login_info.sql
+++ b/sql/user_login_info.sql
@@ -2,7 +2,7 @@ CREATE TABLE user_login_info (
     id INT(4) NOT NULL AUTO_INCREMENT UNIQUE COMMENT 'ID',
     login_id CHAR(10) NOT NULL PRIMARY KEY COMMENT 'ログインID',
     password CHAR(20) NOT NULL COMMENT 'パスワード',
-    category INT(1) NULL COMMENT '権限',
+    category INT(1) NULL COMMENT 'ユーザー種別',
     regist_date TIMESTAMP NOT NULL COMMENT '登録日',
     update_date TIMESTAMP NULL COMMENT '更新日'
 )COMMENT = '会員機能ログイン情報'


### PR DESCRIPTION
# 会員機能管理テーブルの修正

## 修正点
- 物理名categoryのコメントが __ユーザー種別__ でないといけないところが __権限__ となっていたため修正しました
<img width="932" alt="image" src="https://github.com/user-attachments/assets/45f29684-2397-4fe0-908a-753b6352144c">

- DB設計書
https://docs.google.com/spreadsheets/d/1sqhKSvu4r9zRNI_XSk-UZHo4xCWC70wn/edit?gid=654002870#gid=654002870
